### PR TITLE
Handle multiple shapefiles in one zip

### DIFF
--- a/dist/shp.js
+++ b/dist/shp.js
@@ -988,12 +988,13 @@ shp.parseZip = function(buffer){
 				zip[key]=shp.proj(String.fromCharCode.apply(this,new Uint8Array(zip[key])));
 			}
 		}
-	var geojson = {}
-	names.forEach(function(name){
-		geojson[name] = shp.combine([shp.parseShp(zip[name +'.shp'],zip[name +'.prj']),zip[name +'.dbf']]);
+	var geojson = names.map(function(name){
+		var parsed =  shp.combine([shp.parseShp(zip[name +'.shp'],zip[name +'.prj']),zip[name +'.dbf']]);
+		parsed.fileName = name;
+		return parsed;
 	});
-	if(Object.keys(geojson).length === 1){
-		return geojson[Object.keys(geojson)];
+	if(geojson.length === 1){
+		return geojson[0];
 	}else{
 		return geojson;
 	}

--- a/localfile/index.html
+++ b/localfile/index.html
@@ -128,18 +128,19 @@ var NewButton= L.Control.extend({//creating the buttons
        handleFile(file);
    }
    function handleFile(file){
+		var addIt = function(geoJson){
+			lc.addOverlay(L.geoJson(geoJson,options).addTo(m),geoJson.fileName);
+		}
    	    var reader = new FileReader();
         reader.onload=function(){
            	if(reader.readyState !== 2 || reader.error){
            		return;
            	}else{
            		worker.data(reader.result,[reader.result]).then(function(geoJson){
-           			if(geoJson.type){
-           				lc.addOverlay(L.geoJson(geoJson,options).addTo(m),file.name.slice(0,-4));
+           			if(Array.isArray(geoJson)){
+           				geoJson.forEach(addIt)
            			}else{
-           				for(var key in geoJson){
-           					lc.addOverlay(L.geoJson(geoJson[key],options).addTo(m),key);
-           				}
+	           			addIt(geoJson);
            			}
            		},function(a){console.log(a)});
            }

--- a/src/bottom.js
+++ b/src/bottom.js
@@ -27,12 +27,13 @@ shp.parseZip = function(buffer){
 				zip[key]=shp.proj(String.fromCharCode.apply(this,new Uint8Array(zip[key])));
 			}
 		}
-	var geojson = {}
-	names.forEach(function(name){
-		geojson[name] = shp.combine([shp.parseShp(zip[name +'.shp'],zip[name +'.prj']),zip[name +'.dbf']]);
+	var geojson = names.map(function(name){
+		var parsed =  shp.combine([shp.parseShp(zip[name +'.shp'],zip[name +'.prj']),zip[name +'.dbf']]);
+		parsed.fileName = name;
+		return parsed;
 	});
-	if(Object.keys(geojson).length === 1){
-		return geojson[Object.keys(geojson)];
+	if(geojson.length === 1){
+		return geojson[0];
 	}else{
 		return geojson;
 	}


### PR DESCRIPTION
now if there is only one .shp inside a .zip it still returns a geojson file but if there are multiple ones it returns an object with the name (minus the .shp) as the key and the geojson as the value.
