### PR TITLE
add XMLHttpRequest dependencies to avoid issues when running serverside

### DIFF
--- a/dist/shp.js
+++ b/dist/shp.js
@@ -1,5 +1,6 @@
 !function(e){if("object"==typeof exports)module.exports=e();else if("function"==typeof define&&define.amd)define(e);else{var f;"undefined"!=typeof window?f=window:"undefined"!=typeof global?f=global:"undefined"!=typeof self&&(f=self),f.shp=e()}}(function(){var define,module,exports;return (function e(t,n,r){function s(o,u){if(!n[o]){if(!t[o]){var a=typeof require=="function"&&require;if(!u&&a)return a(o,!0);if(i)return i(o,!0);throw new Error("Cannot find module '"+o+"'")}var f=n[o]={exports:{}};t[o][0].call(f.exports,function(e){var n=t[o][1][e];return s(n?n:e)},f,f.exports,e,t,n,r)}return n[o].exports}var i=typeof require=="function"&&require;for(var o=0;o<r.length;o++)s(r[o]);return s})({1:[function(_dereq_,module,exports){
-var promise = _dereq_('lie');
+var promise = _dereq_('lie');,
+(typeof XMLHttpRequest !== 'undefined') || (XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest);
 function binaryAjax(url){
 	return promise(function(resolve,reject){
 		var type = url.slice(-3);

--- a/lib/binaryajax.js
+++ b/lib/binaryajax.js
@@ -1,4 +1,5 @@
 var promise = require('lie');
+(typeof XMLHttpRequest !== 'undefined') || (XMLHttpRequest = require('xmlhttprequest').XMLHttpRequest);
 function binaryAjax(url){
 	return promise(function(resolve,reject){
 		var type = url.slice(-3);

--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "lie": "~2.5.3",
     "lie-all": "~0.1.5",
     "jszip": "git://github.com/calvinmetcalf/jszip.git#nobuffer",
-    "proj4": "~2.1.0"
+    "proj4": "~2.1.0",
+    "xmlhttprequest": "1.6.0"
   }
 }


### PR DESCRIPTION
This fix was required for the framework to run in a nodejs environment as XMLHttpRequest must be included. Note the fix only solves a crash upon loading, I have run successfully with other workarounds in calling code to avoid broken parameters. Namely:
##### You must load the library as below, since properties are not correctly assigned to the toplevel `shp` function:

```
shp = require('shpjs'),
shpModule = require.cache[require.resolve('shpjs')],
shpReader = require('shpjs/lib/parseShp'),
proj = shpModule.require('proj4');
```
##### You'll need to bypass the shapefile loading and do it directly since you're loading a local file and have no `ArrayBuffer` support on the server:

```
function toArrayBuffer(buffer) {
    var ab = new ArrayBuffer(buffer.length);
    var view = new Uint8Array(ab);
    for (var i = 0; i < buffer.length; ++i) {
        view[i] = buffer[i];
    }
    return ab;
}

var inFile = "something.shp",
    fs = require('fs'),
    projection = proj(/* your WKT transformation string here */);

try {
    var buff = new Buffer(fs.readFileSync(inFile)),
        aBuff = toArrayBuffer(buff),
        shapeData = shpReader(aBuff, projection);
} catch (e) {
    // some error in reading the file data
}

// shape data JSON is now stored in `shapeData`.
```
