### PR TITLE
Added Central_Parallel to list object

### DIFF
--- a/dist/shp.js
+++ b/dist/shp.js
@@ -7824,6 +7824,7 @@ function cleanWKT(wkt) {
     ['false_easting', 'False_Easting'],
     ['false_northing', 'False_Northing'],
     ['central_meridian', 'Central_Meridian'],
+    ['latitude_of_origin', 'Central_Parallel'],
     ['latitude_of_origin', 'Latitude_Of_Origin'],
     ['scale_factor', 'Scale_Factor'],
     ['k0', 'scale_factor'],


### PR DESCRIPTION
Found a .prj file with a 'Central_Parallel' parameter.
Features weren't aligning correctly in the y axis
Simply aliased 'Central_Parallel' to 'latitude_of_origin' and features projected correctly.

```
PROJCS["Custom",GEOGCS[
"GCS_North_American_1983",
DATUM[
"D_North_American_1983",
SPHEROID["GRS_1980",6378137.0,298.257222101]
],
PRIMEM["Greenwich",0.0],
UNIT["Degree",0.0174532925199433]
],
PROJECTION["Lambert_Conformal_Conic"],
PARAMETER["False_Easting",1312335.958],
PARAMETER["False_Northing",0.0],
PARAMETER["Central_Meridian",-120.5],
PARAMETER["Standard_Parallel_1",43.0],
PARAMETER["Standard_Parallel_2",45.5],
PARAMETER["Central_Parallel",41.75],
UNIT["Foot",0.3048]]
```
