### PR TITLE
Handle mixed case amongst .shp, .prj, .dbf files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -35,10 +35,10 @@ shp.parseZip = function(buffer, whiteList) {
 			names.push(key.slice(0, - 4));
 		}
 		else if (key.slice(-3).toLowerCase() === "dbf") {
-			zip[key] = parseDbf(zip[key]);
+			zip['dbf'] = parseDbf(zip[key]);
 		}
 		else if (key.slice(-3).toLowerCase() === "prj") {
-			zip[key] = proj4(zip[key]);
+			zip['prj'] = proj4(zip[key]);
 		}
 		else if (key.slice(-4).toLowerCase() === "json" || whiteList.indexOf(key.split('.').pop()) > -1) {
 			names.push(key);
@@ -58,7 +58,7 @@ shp.parseZip = function(buffer, whiteList) {
 			parsed.fileName = name;
 		}
 		else {
-			parsed = shp.combine([parseShp(zip[name + '.shp'], zip[name + '.prj']), zip[name + '.dbf']]);
+			parsed = shp.combine([parseShp(zip[name + '.shp'], zip['prj']), zip['dbf']]);
 			parsed.fileName = name;
 		}
 		return parsed;


### PR DESCRIPTION
Encountered a zipped shapefile in the wild with mixed case .dbf, .prj, .shp files.
ftp://ftp02.portlandoregon.gov/CivicApps/Business_Associations_pdx.zip

I'm sure there are other ways to handle this but it seems like something is necessary here...
