### PR TITLE
Skipping Mac OSX Resource Forks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,9 @@ shp.parseZip = function(buffer, whiteList) {
 	var names = [];
 	whiteList = whiteList || [];
 	for (key in zip) {
+		if (key.lastIndexOf('__MACOSX', 0) !== 0) {
+			continue;
+		}
 		if (key.slice(-3).toLowerCase() === 'shp') {
 			names.push(key.slice(0, - 4));
 		}


### PR DESCRIPTION
Zip files created in Mac OS X contain files hidden in __MACOSX folder, those files have the same extension as the files we're looking for in the zip archive, so they get treated as the real ones and cause problems.
