### PR TITLE
Project coords in feature bbox

### DIFF
--- a/lib/parseShp.js
+++ b/lib/parseShp.js
@@ -83,11 +83,13 @@ ParseShp.prototype.parseZArrayGroup = function(data,zOffset,num,coordinates){
 };
 ParseShp.prototype.parseMultiPoint = function (data){
 	var out = {};
+	var mins = this.parseCoord(data,0);
+	var maxs = this.parseCoord(data,16);
 	out.bbox = [
-		data.getFloat64(0,true),
-		data.getFloat64(8,true),
-		data.getFloat64(16,true),
-		data.getFloat64(24,true)
+		mins[0],
+		mins[1],
+		maxs[0],
+		maxs[1]
 	];
 	var num = data.getInt32(32,true);
 	var offset = 36;
@@ -115,11 +117,13 @@ ParseShp.prototype.parseZMultiPoint = function(data){
 };
 ParseShp.prototype.parsePolyline = function (data){
 	var out = {};
+	var mins = this.parseCoord(data,0);
+	var maxs = this.parseCoord(data,16);
 	out.bbox = [
-		data.getFloat64(0,true),
-		data.getFloat64(8,true),
-		data.getFloat64(16,true),
-		data.getFloat64(24,true)
+		mins[0],
+		mins[1],
+		maxs[0],
+		maxs[1]
 	];
 	var numParts = data.getInt32(32,true);
 	var num = data.getInt32(36,true);


### PR DESCRIPTION
Was wanting to use the geojson bbox for Leaflet mappy stuff....bbox coords were in native proj... seems to make the most sense to apply the parseCoord method to the bbox coords while converting. yay