### PR TITLE
Fixed issue which caused .shp to not be found when mixed case  file name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,6 +48,7 @@ shp.parseZip = function(buffer, whiteList) {
 		}
 		if (key.slice(-3).toLowerCase() === 'shp') {
 			names.push(key.slice(0, - 4));
+			zip[key.slice(0, -3) + key.slice(-3).toLowerCase()] = zip[key];
 		}
 		else if (key.slice(-3).toLowerCase() === 'dbf') {
 			zip[key.slice(0, -3) + key.slice(-3).toLowerCase()] = parseDbf(zip[key]);


### PR DESCRIPTION
This is really just an add-on to https://github.com/calvinmetcalf/shapefile-js/pull/30