### PR TITLE
Fix for encoding

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -55,11 +55,12 @@ shp.combine = function(arr) {
   }
   return out;
 };
-shp.parseZip = function(buffer, whiteList) {
+shp.parseZip = function(buffer, whiteList, encoding) {
   var key;
   buffer = toBuffer(buffer);
   var zip = unzip(buffer);
   var names = [];
+  encoding = encoding || "utf-8"
   whiteList = whiteList || [];
   for (key in zip) {
     if (key.indexOf('__MACOSX') !== -1) {
@@ -90,7 +91,9 @@ shp.parseZip = function(buffer, whiteList) {
       parsed.fileName = name;
     } else {
       if (zip[name + '.dbf']) {
-        dbf = parseDbf(zip[name + '.dbf'], zip[name + '.cpg']);
+        dbf = parseDbf(zip[name + '.dbf'], encoding);
+      } else if (zip[name + '.cpg']) {
+        dbf = parseDbf(zip[name + '.cpg'], encoding);
       }
       parsed = shp.combine([parseShp(zip[name + '.shp'], zip[name + '.prj']), dbf]);
       parsed.fileName = name;


### PR DESCRIPTION
 - parseZip now takes encoding parameter and parses it to parseDbf. defaults to "utf-8"

I've no idea what to do about the .cpg code though...