### PR TITLE
Fix parsing of single points with Z coordinates.

### DIFF
--- a/lib/parseShp.js
+++ b/lib/parseShp.js
@@ -30,7 +30,7 @@ ParseShp.prototype.parsePoint = function(data) {
 };
 ParseShp.prototype.parseZPoint = function(data) {
   var pointXY = this.parsePoint(data);
-  pointXY.coordinates.push(this.parseCoord(data, 16));
+  pointXY.coordinates.push(data.readDoubleLE(16));
   return pointXY;
 };
 ParseShp.prototype.parsePointArray = function(data, offset, num) {


### PR DESCRIPTION
Single points with Z coordinates did not work because the library tried to read the Z coordinate as two doubles instead of one.