### PR TITLE
Use `export default` in binaryajax-fetch.js

### DIFF
--- a/lib/binaryajax-fetch.js
+++ b/lib/binaryajax-fetch.js
@@ -1,7 +1,7 @@
 'use strict';
 var fallback = require('./binaryajax-browser');
 var Buffer = require('buffer').Buffer
-module.exports = async function binaryAjax(url){
+export default async function binaryAjax(url){
   if (!global.fetch) {
     return fallback(url)
   }


### PR DESCRIPTION
Fixing Uncaught TypeError: Cannot assign to read only property 'exports' of object '[object Object]' in Angular 10