### PR TITLE
Fixes parsing of null shapes

### DIFF
--- a/lib/parseShp.js
+++ b/lib/parseShp.js
@@ -255,6 +255,8 @@ ParseShp.prototype.getRows = function() {
     offset += current.len;
     if (current.type) {
       out.push(this.parseFunc(current.data));
+    } else {
+      out.push(null);
     }
   }
   return out;


### PR DESCRIPTION
Fixes #134

The current implementation skips over null shapes in shapefiles resulting in a mismatch between shape data in .shp and .dbf files.

This fix parses null shapes as empty coordinate polygons instead of skipping them to maintain the 1 to 1 relationship between the shape data in the two files.

Example with [badshp.zip](https://github.com/calvinmetcalf/shapefile-js/files/5412815/badshp.zip) on http://leaflet.calvinmetcalf.com/#6/-33.596/138.076
Before fix:
<img width="401" alt="90097530-fccd6a80-dcea-11ea-90fc-886215d24467" src="https://user-images.githubusercontent.com/12361859/96664621-0df8b000-1308-11eb-8feb-2c7eb59f76cd.png">
After fix:
<img width="397" alt="Screen Shot 2020-10-20 at 7 02 48 PM" src="https://user-images.githubusercontent.com/12361859/96664632-14872780-1308-11eb-9eb2-424866e49cfd.png">


