### PR TITLE
Added the proj parameter to the parseShp call

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -159,7 +159,7 @@ shp.parseShp = function(shp, prj) {
       prj = false;
     }
   }
-  return parseShp(shp);
+  return parseShp(shp, prj);
 
 };
 shp.parseDbf = function(dbf, cpg) {


### PR DESCRIPTION
It seems that the inverse projection never occured when the files (.shp, .prj) were used out of a zip file.
I tested by adding the projection parameter 'prj' in the parseShp call and it seems that now the inverse projection is performed when the .prj file is passed along with the .shp file (with the combine function).