### PR TITLE
Update parseShp.js: fixed reading BoundingBox Ymax from the header

### DIFF
--- a/lib/parseShp.js
+++ b/lib/parseShp.js
@@ -258,7 +258,7 @@ ParseShp.prototype.parseHeader = function () {
       view.readDoubleLE(9 << 2),
       view.readDoubleLE(11 << 2),
       view.readDoubleLE(13 << 2),
-      view.readDoubleLE(13 << 2)
+      view.readDoubleLE(15 << 2)
     ]
   };
 };


### PR DESCRIPTION
Thank you for the shapefile-js lib. Here is a tiny fix to read the correct value for the BoundingBox Ymax.