### PR TITLE
Adds .js extension to imports for Webpack 5

### DIFF
--- a/lib/binaryajax-browser.js
+++ b/lib/binaryajax-browser.js
@@ -1,5 +1,5 @@
 
-import combine from './combine';
+import combine from './combine.js';
 import { Buffer } from 'buffer'
 export default binaryAjax;
 function binaryAjax(_url, type) {

--- a/lib/binaryajax-fetch.js
+++ b/lib/binaryajax-fetch.js
@@ -1,5 +1,5 @@
-import fallback from './binaryajax-browser';
-import combine from './combine';
+import fallback from './binaryajax-browser.js';
+import combine from './combine.js';
 import { Buffer } from 'buffer'
 
 export default async function binaryAjax(_url, type) {


### PR DESCRIPTION
Webpack 5 doesn't seem to like non-qualified imports so I just added the .js extension to some imports.

Thank you for your amazing lib!