### PR TITLE
Add a LICENSE.md file to the repository.

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,26 @@
+The MIT License (MIT)
+=====================
+
+Copyright © 2024 - Calvin Metcalf and other `shapefile-js` contributors.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the “Software”), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED “AS IS”, WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+


### PR DESCRIPTION
Hey,

I noticed that this project didn't have a license, but was labeled as being licensed under MIT inside the `package.json` file. Is the project licensed under MIT? If so, here's a PR to add the license to the repository as an explicit `LICENSE.md` file. Alternatively, the `package.json` file could be updated to remove the license.

Thanks,
Om